### PR TITLE
fix: prevent tasks from disappearing with auto-advance enabled

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -169,8 +169,8 @@ export async function pullFromSupabase(): Promise<void> {
           // Item was just created/modified locally — keep it
           localNewer.push(localItems[id]);
         } else if (!itemsPullDone) {
-          // First pull: local item not on remote = deleted on another device
-          delete merged[id];
+          // First pull: local item not on remote = treat as new local item, keep and push
+          localNewer.push(localItems[id]);
         } else if (knownRemoteIds.has(id)) {
           // Was on remote before but now gone — deleted on another device
           delete merged[id];


### PR DESCRIPTION
## Summary
- Fixes sync race condition where local tasks were deleted during first pull when not found on remote server
- Changes behavior to treat local-only items on first pull as new items to push rather than deleted items to remove
- Resolves issue where auto-advance functionality would cause tasks to disappear from user's view

## Root Cause
The bug occurred due to an overly aggressive sync strategy in `src/lib/sync.ts`. During the first pull from Supabase:

1. User creates tasks locally 
2. Auto-advance runs and potentially modifies tasks
3. `pullFromSupabase()` runs for the first time
4. Sync logic sees local items not on remote server and assumes they were "deleted on another device" 
5. Local tasks get deleted from the merged state
6. Tasks disappear from user's view

## Solution
Modified the sync logic in `pullFromSupabase()` to treat local items not found on the remote server during first pull as new local items that should be pushed to the server, rather than deleted items.

## Test Plan
- [ ] Verify tasks no longer disappear when auto-advance is enabled
- [ ] Test that legitimate sync deletions (items deleted on other devices) still work correctly after first pull
- [ ] Confirm no regression in normal sync behavior

🤖 Generated with [Claude Code](https://claude.ai/code)