### PR TITLE
fix: improve item selection UX by requiring focused click to edit

### DIFF
--- a/src/components/items/NoteItem.tsx
+++ b/src/components/items/NoteItem.tsx
@@ -84,17 +84,23 @@ export function NoteItem({
 
   const handleContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (isEditing) return;
-    let offset = item.text.length;
-    if (document.caretRangeFromPoint) {
-      const range = document.caretRangeFromPoint(e.clientX, e.clientY);
-      if (range) offset = range.startOffset;
-    } else if ('caretPositionFromPoint' in document) {
-      const pos = (document as unknown as { caretPositionFromPoint: (x: number, y: number) => { offset: number } | null }).caretPositionFromPoint(e.clientX, e.clientY);
-      if (pos) offset = pos.offset;
+    
+    // If item is already focused/selected, enter edit mode
+    if (isFocused) {
+      let offset = item.text.length;
+      if (document.caretRangeFromPoint) {
+        const range = document.caretRangeFromPoint(e.clientX, e.clientY);
+        if (range) offset = range.startOffset;
+      } else if ('caretPositionFromPoint' in document) {
+        const pos = (document as unknown as { caretPositionFromPoint: (x: number, y: number) => { offset: number } | null }).caretPositionFromPoint(e.clientX, e.clientY);
+        if (pos) offset = pos.offset;
+      }
+      cursorPosRef.current = offset;
+      setIsEditing(true);
+    } else {
+      // First click: just select the item for manipulation
+      onSelect?.();
     }
-    cursorPosRef.current = offset;
-    onSelect?.();
-    setIsEditing(true);
   };
 
   const handleContainerKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/items/TaskItem.tsx
+++ b/src/components/items/TaskItem.tsx
@@ -124,17 +124,23 @@ export function TaskItem({
 
   const handleContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (isEditing) return;
-    let offset = item.text.length;
-    if (document.caretRangeFromPoint) {
-      const range = document.caretRangeFromPoint(e.clientX, e.clientY);
-      if (range) offset = range.startOffset;
-    } else if ('caretPositionFromPoint' in document) {
-      const pos = (document as unknown as { caretPositionFromPoint: (x: number, y: number) => { offset: number } | null }).caretPositionFromPoint(e.clientX, e.clientY);
-      if (pos) offset = pos.offset;
+    
+    // If item is already focused/selected, enter edit mode
+    if (isFocused) {
+      let offset = item.text.length;
+      if (document.caretRangeFromPoint) {
+        const range = document.caretRangeFromPoint(e.clientX, e.clientY);
+        if (range) offset = range.startOffset;
+      } else if ('caretPositionFromPoint' in document) {
+        const pos = (document as unknown as { caretPositionFromPoint: (x: number, y: number) => { offset: number } | null }).caretPositionFromPoint(e.clientX, e.clientY);
+        if (pos) offset = pos.offset;
+      }
+      cursorPosRef.current = offset;
+      setIsEditing(true);
+    } else {
+      // First click: just select the item for manipulation
+      onSelect?.();
     }
-    cursorPosRef.current = offset;
-    onSelect?.();
-    setIsEditing(true);
   };
 
   // Keyboard handler for manipulating mode (only fires when container has DOM focus).


### PR DESCRIPTION
Fixes #10

## Summary
- Clicking on an item in the inbox no longer immediately enters edit mode
- First click selects/focuses the item; second click on the focused item enters edit mode
- Applied to both TaskItem and NoteItem for consistency

## Test plan
- [ ] Click on an item in the inbox — should select/focus (blue highlight) without entering edit
- [ ] Click again on the focused item — should enter edit mode
- [ ] Verify keyboard navigation (arrow keys, Enter to edit) still works
- [ ] Test with both task items and note items
- [ ] Ensure drag handles and other buttons still work

---
_Auto-generated fix from bug report — pipeline run [25442246364](https://github.com/leobabauta/zenmode/actions/runs/25442246364). Awaits human review before merge._