### PR TITLE
fix: improve gesture detection to prevent scroll interference on Android landscape

### DIFF
--- a/mobile/src/components/SwipeableRow.tsx
+++ b/mobile/src/components/SwipeableRow.tsx
@@ -79,8 +79,10 @@ export function SwipeableRow({ children, onTomorrow, onSnooze, onMoveToInbox, on
 
   const panGesture = Gesture.Pan()
     .enabled(enabled)
-    .activeOffsetX([-8, 8])
-    .failOffsetY([-40, 40])
+    .activeOffsetX([-12, 12])
+    .failOffsetY([-20, 20])
+    .minPointers(1)
+    .maxPointers(1)
     .onUpdate((event) => {
       'worklet';
       translateX.value = Math.max(-maxLeft, Math.min(maxRight, event.translationX));


### PR DESCRIPTION
Fixes #15

## Summary
- Fixed Android landscape scrolling issue where users could only scroll by swiping at screen edges
- Improved SwipeableRow gesture detection to better distinguish between horizontal swipes and vertical scrolling

## What was wrong
The SwipeableRow component's pan gesture was using overly broad detection parameters that interfered with vertical scrolling in landscape orientation on Android devices. The `activeOffsetX` threshold was too low (8px) and `failOffsetY` was too high (40px), causing the swipe gesture to capture vertical scroll attempts.

## How it was fixed
- Increased `activeOffsetX` from `[-8, 8]` to `[-12, 12]` to require more intentional horizontal gestures
- Reduced `failOffsetY` from `[-40, 40]` to `[-20, 20]` to fail faster on vertical gestures
- Added `minPointers(1).maxPointers(1)` to constrain to single-touch gestures only

This makes the gesture recognition more precise and prevents interference with FlatList scrolling.

## Test plan
- [ ] Test on Android device in landscape orientation
- [ ] Verify vertical scrolling works throughout the entire list area
- [ ] Confirm horizontal swipe actions still work as expected
- [ ] Test on iOS to ensure no regression

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_