### PR TITLE
fix: show past incomplete items when auto-advance disabled

### DIFF
--- a/src/components/today/TodayView.tsx
+++ b/src/components/today/TodayView.tsx
@@ -10,6 +10,7 @@ import { CopyButton } from '../ui/CopyButton';
 
 export function TodayView() {
   const items = usePlannerStore((s) => s.items);
+  const autoAdvanceEnabled = usePlannerStore((s) => s.autoAdvanceEnabled);
   const setView = usePlannerStore((s) => s.setView);
   const reviewRitualEnabled = usePlannerStore((s) => s.reviewRitualEnabled);
   const lastReviewRitualDate = usePlannerStore((s) => s.lastReviewRitualDate);
@@ -20,7 +21,34 @@ export function TodayView() {
 
   const today = new Date();
   const dayKey = toDayKey(today);
-  const todayItems = selectItemsForDay(items, dayKey);
+  const baseTodayItems = selectItemsForDay(items, dayKey);
+  
+  // When auto-advance is disabled, also include past incomplete items
+  const todayItems = useMemo(() => {
+    if (autoAdvanceEnabled) {
+      return baseTodayItems;
+    }
+    
+    // Get past incomplete items (excluding notes and subtasks)
+    const pastIncomplete = Object.values(items).filter(
+      (i) =>
+        i.dayKey !== null &&
+        i.dayKey < dayKey &&
+        !i.completed &&
+        !i.isLater &&
+        !i.parentId &&
+        !i.isArchived &&
+        i.type !== 'note'
+    );
+    
+    // Combine and sort: today's items first, then past items by date (newest first)
+    const combined = [...baseTodayItems];
+    pastIncomplete
+      .sort((a, b) => (b.dayKey || '').localeCompare(a.dayKey || ''))
+      .forEach(item => combined.push(item));
+    
+    return combined;
+  }, [baseTodayItems, autoAdvanceEnabled, items, dayKey]);
   const pendingReminders = selectPendingRemindersForDay(items, dayKey);
   const [showReminders, setShowReminders] = useState(false);
   const deleteItem = usePlannerStore((s) => s.deleteItem);

--- a/src/components/today/TodayView.tsx
+++ b/src/components/today/TodayView.tsx
@@ -11,6 +11,9 @@ import { CopyButton } from '../ui/CopyButton';
 export function TodayView() {
   const items = usePlannerStore((s) => s.items);
   const autoAdvanceEnabled = usePlannerStore((s) => s.autoAdvanceEnabled);
+  const setAutoAdvanceEnabled = usePlannerStore((s) => s.setAutoAdvanceEnabled);
+  const showPastIncompleteInToday = usePlannerStore((s) => s.showPastIncompleteInToday);
+  const setShowPastIncompleteInToday = usePlannerStore((s) => s.setShowPastIncompleteInToday);
   const setView = usePlannerStore((s) => s.setView);
   const reviewRitualEnabled = usePlannerStore((s) => s.reviewRitualEnabled);
   const lastReviewRitualDate = usePlannerStore((s) => s.lastReviewRitualDate);
@@ -21,34 +24,25 @@ export function TodayView() {
 
   const today = new Date();
   const dayKey = toDayKey(today);
-  const baseTodayItems = selectItemsForDay(items, dayKey);
-  
-  // When auto-advance is disabled, also include past incomplete items
-  const todayItems = useMemo(() => {
-    if (autoAdvanceEnabled) {
-      return baseTodayItems;
-    }
-    
-    // Get past incomplete items (excluding notes and subtasks)
-    const pastIncomplete = Object.values(items).filter(
-      (i) =>
-        i.dayKey !== null &&
-        i.dayKey < dayKey &&
-        !i.completed &&
-        !i.isLater &&
-        !i.parentId &&
-        !i.isArchived &&
-        i.type !== 'note'
-    );
-    
-    // Combine and sort: today's items first, then past items by date (newest first)
-    const combined = [...baseTodayItems];
-    pastIncomplete
-      .sort((a, b) => (b.dayKey || '').localeCompare(a.dayKey || ''))
-      .forEach(item => combined.push(item));
-    
-    return combined;
-  }, [baseTodayItems, autoAdvanceEnabled, items, dayKey]);
+  const todayItems = selectItemsForDay(items, dayKey);
+
+  // When auto-advance is disabled and the section isn't hidden, surface past
+  // incomplete tasks in a distinct section below today's items.
+  const pastIncompleteItems = useMemo(() => {
+    if (autoAdvanceEnabled || !showPastIncompleteInToday) return [];
+    return Object.values(items)
+      .filter(
+        (i) =>
+          i.dayKey !== null &&
+          i.dayKey < dayKey &&
+          !i.completed &&
+          !i.isLater &&
+          !i.parentId &&
+          !i.isArchived &&
+          i.type !== 'note',
+      )
+      .sort((a, b) => (b.dayKey || '').localeCompare(a.dayKey || ''));
+  }, [items, autoAdvanceEnabled, showPastIncompleteInToday, dayKey]);
   const pendingReminders = selectPendingRemindersForDay(items, dayKey);
   const [showReminders, setShowReminders] = useState(false);
   const deleteItem = usePlannerStore((s) => s.deleteItem);
@@ -210,6 +204,28 @@ export function TodayView() {
               </div>
               <AddItemForm dayKey={dayKey} className="mt-1" />
               <SortArchiveButtons items={todayItems} />
+              {pastIncompleteItems.length > 0 && (
+                <div className="mt-6 pt-4 border-t border-[var(--color-border)]">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-2">
+                    Past unfinished ({pastIncompleteItems.length})
+                  </h3>
+                  <ItemList items={pastIncompleteItems} />
+                  <div className="mt-3 flex gap-2 text-xs">
+                    <button
+                      onClick={() => setShowPastIncompleteInToday(false)}
+                      className="px-2.5 py-1 rounded-md border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text-primary)] transition-colors"
+                    >
+                      Hide from Today
+                    </button>
+                    <button
+                      onClick={() => setAutoAdvanceEnabled(true)}
+                      className="px-2.5 py-1 rounded-md border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text-primary)] transition-colors"
+                    >
+                      Turn on auto-advance
+                    </button>
+                  </div>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/store/usePlannerStore.ts
+++ b/src/store/usePlannerStore.ts
@@ -78,6 +78,7 @@ interface PlannerState {
   hasCompletedOnboarding: boolean;
   onboardingCompletedDate: string | null;
   collapsedItemIds: Set<string>;
+  showPastIncompleteInToday: boolean;
 
   getLabelColor: (tag: string) => string;
   setLabelColor: (tag: string, color: string) => void;
@@ -154,6 +155,7 @@ interface PlannerState {
   unarchiveItem: (id: string) => void;
   setAutoAdvanceEnabled: (v: boolean) => void;
   setAutoAdvanceLaterDays: (v: number) => void;
+  setShowPastIncompleteInToday: (v: boolean) => void;
   reorderNav: (orderedIds: string[]) => void;
   reorderLabels: (orderedTags: string[]) => void;
   startSelection: (id: string | null) => void;
@@ -229,6 +231,7 @@ export const usePlannerStore = create<PlannerState>()(
       hasCompletedOnboarding: false,
       onboardingCompletedDate: null,
       collapsedItemIds: new Set(),
+      showPastIncompleteInToday: true,
 
       getLabelColor: (tag: string) => {
         const key = tag.toLowerCase();
@@ -1112,6 +1115,9 @@ export const usePlannerStore = create<PlannerState>()(
       setAutoAdvanceLaterDays: (v) => {
         set((state) => { state.autoAdvanceLaterDays = v; });
       },
+      setShowPastIncompleteInToday: (v) => {
+        set((state) => { state.showPastIncompleteInToday = v; });
+      },
       sortCompletedToTop: (context) => {
         const state = get();
         let itemList: PlannerItem[];
@@ -1211,7 +1217,7 @@ export const usePlannerStore = create<PlannerState>()(
     })),
     {
       name: 'zenmode-v1',
-      partialize: (state) => ({ items: state.items, theme: state.theme, view: state.view, activeHashtag: state.activeHashtag, labelColors: state.labelColors, lastRitualDate: state.lastRitualDate, planningRitualEnabled: state.planningRitualEnabled, planningRitualHour: state.planningRitualHour, planningRitualMinute: state.planningRitualMinute, planningRitualSnoozedUntil: state.planningRitualSnoozedUntil, reviewRitualEnabled: state.reviewRitualEnabled, reviewRitualHour: state.reviewRitualHour, reviewRitualMinute: state.reviewRitualMinute, reviewRitualSnoozedUntil: state.reviewRitualSnoozedUntil, lastReviewRitualDate: state.lastReviewRitualDate, customLists: state.customLists, activeListId: state.activeListId, weeklyPlans: state.weeklyPlans, weeklyReviews: state.weeklyReviews, weeklyPlanningEnabled: state.weeklyPlanningEnabled, weeklyPlanningDay: state.weeklyPlanningDay, weeklyPlanningHour: state.weeklyPlanningHour, weeklyPlanningSnoozedUntil: state.weeklyPlanningSnoozedUntil, weeklyReviewEnabled: state.weeklyReviewEnabled, weeklyReviewDay: state.weeklyReviewDay, weeklyReviewHour: state.weeklyReviewHour, weeklyReviewMinute: state.weeklyReviewMinute, weeklyReviewSnoozedUntil: state.weeklyReviewSnoozedUntil, lastWeeklyPlanningDate: state.lastWeeklyPlanningDate, lastWeeklyReviewDate: state.lastWeeklyReviewDate, navOrder: state.navOrder, labelOrder: state.labelOrder, autoAdvanceEnabled: state.autoAdvanceEnabled, autoAdvanceLaterDays: state.autoAdvanceLaterDays, lastAutoMoveDate: state.lastAutoMoveDate, hasCompletedOnboarding: state.hasCompletedOnboarding, onboardingCompletedDate: state.onboardingCompletedDate, collapsedItemIds: Array.from(state.collapsedItemIds) }),
+      partialize: (state) => ({ items: state.items, theme: state.theme, view: state.view, activeHashtag: state.activeHashtag, labelColors: state.labelColors, lastRitualDate: state.lastRitualDate, planningRitualEnabled: state.planningRitualEnabled, planningRitualHour: state.planningRitualHour, planningRitualMinute: state.planningRitualMinute, planningRitualSnoozedUntil: state.planningRitualSnoozedUntil, reviewRitualEnabled: state.reviewRitualEnabled, reviewRitualHour: state.reviewRitualHour, reviewRitualMinute: state.reviewRitualMinute, reviewRitualSnoozedUntil: state.reviewRitualSnoozedUntil, lastReviewRitualDate: state.lastReviewRitualDate, customLists: state.customLists, activeListId: state.activeListId, weeklyPlans: state.weeklyPlans, weeklyReviews: state.weeklyReviews, weeklyPlanningEnabled: state.weeklyPlanningEnabled, weeklyPlanningDay: state.weeklyPlanningDay, weeklyPlanningHour: state.weeklyPlanningHour, weeklyPlanningSnoozedUntil: state.weeklyPlanningSnoozedUntil, weeklyReviewEnabled: state.weeklyReviewEnabled, weeklyReviewDay: state.weeklyReviewDay, weeklyReviewHour: state.weeklyReviewHour, weeklyReviewMinute: state.weeklyReviewMinute, weeklyReviewSnoozedUntil: state.weeklyReviewSnoozedUntil, lastWeeklyPlanningDate: state.lastWeeklyPlanningDate, lastWeeklyReviewDate: state.lastWeeklyReviewDate, navOrder: state.navOrder, labelOrder: state.labelOrder, autoAdvanceEnabled: state.autoAdvanceEnabled, autoAdvanceLaterDays: state.autoAdvanceLaterDays, lastAutoMoveDate: state.lastAutoMoveDate, hasCompletedOnboarding: state.hasCompletedOnboarding, onboardingCompletedDate: state.onboardingCompletedDate, collapsedItemIds: Array.from(state.collapsedItemIds), showPastIncompleteInToday: state.showPastIncompleteInToday }),
       onRehydrateStorage: () => (state) => {
         if (state) {
           // Set initial sidebar state based on restored view
@@ -1236,7 +1242,7 @@ if (typeof window !== 'undefined') {
 // --- Sync subscriber: detect item changes/deletes and preference changes ---
 import { markChanged, markDeleted, pushPreferences, isPullSuppressingDeletes } from '../lib/sync';
 
-const PREF_KEYS = ['theme', 'accentColor', 'view', 'activeHashtag', 'labelColors', 'lastRitualDate', 'planningRitualEnabled', 'planningRitualHour', 'planningRitualSnoozedUntil', 'reviewRitualEnabled', 'reviewRitualHour', 'reviewRitualSnoozedUntil', 'lastReviewRitualDate', 'customLists', 'activeListId', 'weeklyPlans', 'weeklyReviews', 'weeklyPlanningEnabled', 'weeklyPlanningDay', 'weeklyPlanningHour', 'weeklyPlanningSnoozedUntil', 'weeklyReviewEnabled', 'weeklyReviewDay', 'weeklyReviewHour', 'weeklyReviewMinute', 'weeklyReviewSnoozedUntil', 'lastWeeklyPlanningDate', 'lastWeeklyReviewDate', 'navOrder', 'labelOrder', 'autoAdvanceEnabled', 'autoAdvanceLaterDays', 'lastAutoMoveDate'] as const;
+const PREF_KEYS = ['theme', 'accentColor', 'view', 'activeHashtag', 'labelColors', 'lastRitualDate', 'planningRitualEnabled', 'planningRitualHour', 'planningRitualSnoozedUntil', 'reviewRitualEnabled', 'reviewRitualHour', 'reviewRitualSnoozedUntil', 'lastReviewRitualDate', 'customLists', 'activeListId', 'weeklyPlans', 'weeklyReviews', 'weeklyPlanningEnabled', 'weeklyPlanningDay', 'weeklyPlanningHour', 'weeklyPlanningSnoozedUntil', 'weeklyReviewEnabled', 'weeklyReviewDay', 'weeklyReviewHour', 'weeklyReviewMinute', 'weeklyReviewSnoozedUntil', 'lastWeeklyPlanningDate', 'lastWeeklyReviewDate', 'navOrder', 'labelOrder', 'autoAdvanceEnabled', 'autoAdvanceLaterDays', 'lastAutoMoveDate', 'showPastIncompleteInToday'] as const;
 
 usePlannerStore.subscribe((state, prevState) => {
   // Detect changed items


### PR DESCRIPTION
## Summary
- Fixed bug where items created when auto-advance was disabled would disappear from all views
- Modified TodayView to show past incomplete items when auto-advance is disabled
- Items now remain accessible even when auto-advance setting is changed

## Test plan
- [ ] Disable auto-advance in settings
- [ ] Create some tasks in Today view
- [ ] Wait for day to change (or manually change system date)  
- [ ] Verify tasks are still visible in Today view
- [ ] Enable auto-advance and verify tasks remain visible
- [ ] Verify auto-advance behavior still works normally when enabled

🤖 Generated with [Claude Code](https://claude.ai/code)