### PR TITLE
fix: improve sub-list behavior for completed tasks and persist collapse state

### DIFF
--- a/src/components/items/ItemList.tsx
+++ b/src/components/items/ItemList.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useShallow } from 'zustand/react/shallow';
 import { DraggableItem } from './DraggableItem';
@@ -38,6 +37,7 @@ export function ItemList({ items, onCrossPrev, onCrossNext }: ItemListProps) {
   const {
     selectionAnchorId, selectionFocusId,
     startSelection, moveFocus, clearSelection, reorderItems, insertItemAfter,
+    collapsedItemIds, toggleItemCollapse,
   } = usePlannerStore(useShallow((s) => ({
     selectionAnchorId: s.selectionAnchorId,
     selectionFocusId: s.selectionFocusId,
@@ -46,18 +46,10 @@ export function ItemList({ items, onCrossPrev, onCrossNext }: ItemListProps) {
     clearSelection: s.clearSelection,
     reorderItems: s.reorderItems,
     insertItemAfter: s.insertItemAfter,
+    collapsedItemIds: s.collapsedItemIds,
+    toggleItemCollapse: s.toggleItemCollapse,
   })));
   const allItems = usePlannerStore((s) => s.items);
-
-  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
-  const toggleCollapse = (id: string) => {
-    setCollapsedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
 
   const ids = items.map((i) => i.id);
   const dayKey = items[0]?.dayKey ?? null;
@@ -130,8 +122,8 @@ export function ItemList({ items, onCrossPrev, onCrossNext }: ItemListProps) {
             onCrossPrev?.(99999);
           }
         }}
-        onToggleCollapse={!isChild ? () => toggleCollapse(item.id) : undefined}
-        isCollapsed={collapsedIds.has(item.id)}
+        onToggleCollapse={!isChild ? () => toggleItemCollapse(item.id) : undefined}
+        isCollapsed={collapsedItemIds.has(item.id)}
       />
     </div>
   );
@@ -141,7 +133,7 @@ export function ItemList({ items, onCrossPrev, onCrossNext }: ItemListProps) {
       <div className="flex flex-col gap-0.5">
         {items.map((item, index) => {
           const children = selectChildItems(allItems, item.id);
-          const isCollapsed = collapsedIds.has(item.id);
+          const isCollapsed = collapsedItemIds.has(item.id);
           return (
             <div key={item.id}>
               {renderItem(item, index)}

--- a/src/store/usePlannerStore.ts
+++ b/src/store/usePlannerStore.ts
@@ -77,6 +77,7 @@ interface PlannerState {
   lastAutoMoveDate: string | null;
   hasCompletedOnboarding: boolean;
   onboardingCompletedDate: string | null;
+  collapsedItemIds: Set<string>;
 
   getLabelColor: (tag: string) => string;
   setLabelColor: (tag: string, color: string) => void;
@@ -158,6 +159,7 @@ interface PlannerState {
   startSelection: (id: string | null) => void;
   moveFocus: (id: string | null) => void;
   clearSelection: () => void;
+  toggleItemCollapse: (id: string) => void;
 }
 
 export const usePlannerStore = create<PlannerState>()(
@@ -226,6 +228,7 @@ export const usePlannerStore = create<PlannerState>()(
       lastAutoMoveDate: null,
       hasCompletedOnboarding: false,
       onboardingCompletedDate: null,
+      collapsedItemIds: new Set(),
 
       getLabelColor: (tag: string) => {
         const key = tag.toLowerCase();
@@ -1196,14 +1199,29 @@ export const usePlannerStore = create<PlannerState>()(
       clearSelection: () => {
         set((state) => { state.selectionAnchorId = null; state.selectionFocusId = null; });
       },
+      toggleItemCollapse: (id) => {
+        set((state) => {
+          if (state.collapsedItemIds.has(id)) {
+            state.collapsedItemIds.delete(id);
+          } else {
+            state.collapsedItemIds.add(id);
+          }
+        });
+      },
     })),
     {
       name: 'zenmode-v1',
-      partialize: (state) => ({ items: state.items, theme: state.theme, view: state.view, activeHashtag: state.activeHashtag, labelColors: state.labelColors, lastRitualDate: state.lastRitualDate, planningRitualEnabled: state.planningRitualEnabled, planningRitualHour: state.planningRitualHour, planningRitualMinute: state.planningRitualMinute, planningRitualSnoozedUntil: state.planningRitualSnoozedUntil, reviewRitualEnabled: state.reviewRitualEnabled, reviewRitualHour: state.reviewRitualHour, reviewRitualMinute: state.reviewRitualMinute, reviewRitualSnoozedUntil: state.reviewRitualSnoozedUntil, lastReviewRitualDate: state.lastReviewRitualDate, customLists: state.customLists, activeListId: state.activeListId, weeklyPlans: state.weeklyPlans, weeklyReviews: state.weeklyReviews, weeklyPlanningEnabled: state.weeklyPlanningEnabled, weeklyPlanningDay: state.weeklyPlanningDay, weeklyPlanningHour: state.weeklyPlanningHour, weeklyPlanningSnoozedUntil: state.weeklyPlanningSnoozedUntil, weeklyReviewEnabled: state.weeklyReviewEnabled, weeklyReviewDay: state.weeklyReviewDay, weeklyReviewHour: state.weeklyReviewHour, weeklyReviewMinute: state.weeklyReviewMinute, weeklyReviewSnoozedUntil: state.weeklyReviewSnoozedUntil, lastWeeklyPlanningDate: state.lastWeeklyPlanningDate, lastWeeklyReviewDate: state.lastWeeklyReviewDate, navOrder: state.navOrder, labelOrder: state.labelOrder, autoAdvanceEnabled: state.autoAdvanceEnabled, autoAdvanceLaterDays: state.autoAdvanceLaterDays, lastAutoMoveDate: state.lastAutoMoveDate, hasCompletedOnboarding: state.hasCompletedOnboarding, onboardingCompletedDate: state.onboardingCompletedDate }),
+      partialize: (state) => ({ items: state.items, theme: state.theme, view: state.view, activeHashtag: state.activeHashtag, labelColors: state.labelColors, lastRitualDate: state.lastRitualDate, planningRitualEnabled: state.planningRitualEnabled, planningRitualHour: state.planningRitualHour, planningRitualMinute: state.planningRitualMinute, planningRitualSnoozedUntil: state.planningRitualSnoozedUntil, reviewRitualEnabled: state.reviewRitualEnabled, reviewRitualHour: state.reviewRitualHour, reviewRitualMinute: state.reviewRitualMinute, reviewRitualSnoozedUntil: state.reviewRitualSnoozedUntil, lastReviewRitualDate: state.lastReviewRitualDate, customLists: state.customLists, activeListId: state.activeListId, weeklyPlans: state.weeklyPlans, weeklyReviews: state.weeklyReviews, weeklyPlanningEnabled: state.weeklyPlanningEnabled, weeklyPlanningDay: state.weeklyPlanningDay, weeklyPlanningHour: state.weeklyPlanningHour, weeklyPlanningSnoozedUntil: state.weeklyPlanningSnoozedUntil, weeklyReviewEnabled: state.weeklyReviewEnabled, weeklyReviewDay: state.weeklyReviewDay, weeklyReviewHour: state.weeklyReviewHour, weeklyReviewMinute: state.weeklyReviewMinute, weeklyReviewSnoozedUntil: state.weeklyReviewSnoozedUntil, lastWeeklyPlanningDate: state.lastWeeklyPlanningDate, lastWeeklyReviewDate: state.lastWeeklyReviewDate, navOrder: state.navOrder, labelOrder: state.labelOrder, autoAdvanceEnabled: state.autoAdvanceEnabled, autoAdvanceLaterDays: state.autoAdvanceLaterDays, lastAutoMoveDate: state.lastAutoMoveDate, hasCompletedOnboarding: state.hasCompletedOnboarding, onboardingCompletedDate: state.onboardingCompletedDate, collapsedItemIds: Array.from(state.collapsedItemIds) }),
       onRehydrateStorage: () => (state) => {
         if (state) {
           // Set initial sidebar state based on restored view
           state.sidebarCollapsed = state.view === 'today';
+          // Ensure collapsedItemIds is a Set (JSON deserialization might make it an array)
+          if (Array.isArray(state.collapsedItemIds)) {
+            state.collapsedItemIds = new Set(state.collapsedItemIds);
+          } else if (!state.collapsedItemIds) {
+            state.collapsedItemIds = new Set();
+          }
         }
       },
     }
@@ -1277,7 +1295,13 @@ export function selectLaterItems(items: Record<string, PlannerItem>) {
 export function selectChildItems(items: Record<string, PlannerItem>, parentId: string) {
   return Object.values(items)
     .filter((i) => i.parentId === parentId)
-    .sort((a, b) => a.order - b.order);
+    .sort((a, b) => {
+      // Sort completed items to the top, then by order
+      if (a.completed !== b.completed) {
+        return a.completed ? -1 : 1;
+      }
+      return a.order - b.order;
+    });
 }
 
 export function selectCustomListItems(items: Record<string, PlannerItem>, listId: string) {


### PR DESCRIPTION
Fixes #25

## Summary
- Sort completed subtasks to the top, matching the behavior of the main task list
- Persist sub-list collapsed/expanded state across sessions and navigation
- Move collapse state from component-local useState to Zustand store for persistence

## What was wrong
1. When subtasks were completed, they stayed in their original position instead of moving to the top like regular tasks do
2. Sub-list collapse/expand state was lost every time the user navigated away or refreshed the app

## How it was fixed
1. **Completed subtasks to top**: Modified `selectChildItems()` in the store to sort completed items before incomplete ones, matching the behavior of the main task list
2. **Persistent collapse state**: 
   - Added `collapsedItemIds` Set to the Zustand store state
   - Added `toggleItemCollapse` action to manage the collapse state
   - Updated `ItemList` component to use store state instead of local `useState`
   - Added proper serialization/deserialization for the Set in the persist middleware

## Test plan
- [ ] Create a parent task with multiple subtasks
- [ ] Complete some subtasks and verify they move to the top
- [ ] Collapse a sub-list and navigate away/refresh - verify it stays collapsed
- [ ] Expand a sub-list and navigate away/refresh - verify it stays expanded

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_