### PR TITLE
fix: enable multi-item drag and drop within same container

### DIFF
--- a/src/hooks/useDragAndDrop.ts
+++ b/src/hooks/useDragAndDrop.ts
@@ -224,6 +224,10 @@ export function useDragAndDrop() {
     if (sourceContainerKey === targetContainerKey) {
       if (!targetItemId || targetItemId === activeIdStr) return;
 
+      const state = usePlannerStore.getState();
+      const selectedIds = getSelectedItemIds(state.items, state.selectionAnchorId, state.selectionFocusId);
+      const dragIds = selectedIds.includes(activeIdStr) ? selectedIds : [activeIdStr];
+
       const containerItems =
         targetContainerKey === 'inbox'
           ? selectInboxItems(items)
@@ -231,18 +235,43 @@ export function useDragAndDrop() {
           ? selectLaterItems(items)
           : selectItemsForDay(items, targetContainerKey);
 
-      const oldIndex = containerItems.findIndex((i) => i.id === activeIdStr);
-      const newIndex = containerItems.findIndex((i) => i.id === targetItemId);
+      // If dragging multiple items, move them as a group
+      if (dragIds.length > 1) {
+        const dragIdsSet = new Set(dragIds);
+        const nonDraggedItems = containerItems.filter((i) => !dragIdsSet.has(i.id));
+        const targetIndex = nonDraggedItems.findIndex((i) => i.id === targetItemId);
+        
+        if (targetIndex === -1) return;
+        
+        // Insert the dragged items at the target position
+        const reordered = [
+          ...nonDraggedItems.slice(0, targetIndex),
+          ...dragIds.map((id) => items[id]).filter(Boolean),
+          ...nonDraggedItems.slice(targetIndex)
+        ];
+        
+        reorderItems(
+          targetContainerKey === 'inbox' || targetContainerKey === 'later'
+            ? null
+            : targetContainerKey,
+          reordered.map((i) => i.id)
+        );
+      } else {
+        // Single item drag: use existing logic
+        const oldIndex = containerItems.findIndex((i) => i.id === activeIdStr);
+        const newIndex = containerItems.findIndex((i) => i.id === targetItemId);
 
-      if (oldIndex === newIndex) return;
+        if (oldIndex === newIndex) return;
 
-      const reordered = arrayMove(containerItems, oldIndex, newIndex);
-      reorderItems(
-        targetContainerKey === 'inbox' || targetContainerKey === 'later'
-          ? null
-          : targetContainerKey,
-        reordered.map((i) => i.id)
-      );
+        const reordered = arrayMove(containerItems, oldIndex, newIndex);
+        reorderItems(
+          targetContainerKey === 'inbox' || targetContainerKey === 'later'
+            ? null
+            : targetContainerKey,
+          reordered.map((i) => i.id)
+        );
+      }
+      state.clearSelection();
       return;
     }
 


### PR DESCRIPTION
Fixes #28

## Summary
- Fixed multi-item drag and drop within the same container (e.g., reordering multiple selected tasks within the same day)
- Previously only the dragged item would move, now all selected items move together as expected
- Maintains backward compatibility with single-item dragging

## What was wrong
The drag and drop logic in `useDragAndDrop.ts` correctly handled multi-selection for cross-container moves (e.g., dragging multiple items from Inbox to Today), but failed to handle multi-selection for same-container reordering. The reordering logic only considered the single item being dragged, ignoring the rest of the selection.

## How it was fixed
Extended the same-container reordering logic to:
1. Check if the dragged item is part of a multi-selection
2. If so, move all selected items as a group to the target position
3. Otherwise, fall back to the existing single-item logic
4. Clear the selection after reordering (consistent with existing behavior)

The fix aligns with the existing cross-container multi-drag behavior and keyboard-based multi-selection reordering that already worked correctly.

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_