### PR TITLE
fix: enable selection and dragging of parent tasks with subtasks

### DIFF
--- a/src/components/items/TaskItem.tsx
+++ b/src/components/items/TaskItem.tsx
@@ -255,7 +255,11 @@ export function TaskItem({
           onClick={(e) => {
             e.stopPropagation();
             if (e.shiftKey) onExtendSelection?.();
-            else onToggleCollapse();
+            else onSelect?.();
+          }}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            onToggleCollapse();
           }}
           className="flex-shrink-0 w-4 h-4 flex items-center justify-center text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors mt-0.5 cursor-grab active:cursor-grabbing"
         >


### PR DESCRIPTION
## Summary
- Fixes issue where parent tasks with subtasks cannot be selected or dragged in timeline view
- Changes drag handle behavior: single click selects item, double click toggles collapse
- Preserves existing Shift+click behavior for selection extension

## Test plan
- [ ] Create a task with subtasks in timeline view
- [ ] Verify single click on drag handle selects the parent task (enables dragging)  
- [ ] Verify double click on drag handle toggles collapse/expand state
- [ ] Verify Shift+click extends selection as before
- [ ] Verify parent task can now be dragged to other days

🤖 Generated with [Claude Code](https://claude.ai/code)