### PR TITLE
fix: weekly planning on Sunday now targets next week instead of current week

### DIFF
--- a/shared/lib/dates.ts
+++ b/shared/lib/dates.ts
@@ -48,3 +48,15 @@ export function getWeekKey(date: Date = new Date()): string {
   const monday = startOfWeek(date, { weekStartsOn: 1 }); // 1 = Monday
   return format(monday, 'yyyy-MM-dd');
 }
+
+/** Returns the appropriate week key for weekly planning. 
+ * If it's Sunday, returns next week's key (since people want to plan ahead).
+ * Otherwise returns current week's key. */
+export function getWeekKeyForPlanning(date: Date = new Date()): string {
+  if (date.getDay() === 0) { // Sunday is 0
+    // On Sunday, plan for next week
+    const nextWeek = addDays(date, 1); // Move to Monday (next week)
+    return getWeekKey(nextWeek);
+  }
+  return getWeekKey(date);
+}

--- a/src/components/ritual/WeeklyPlanningView.tsx
+++ b/src/components/ritual/WeeklyPlanningView.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { nanoid } from 'nanoid';
 import { usePlannerStore } from '../../store/usePlannerStore';
-import { getWeekKey, toDayKey } from '../../lib/dates';
+import { getWeekKeyForPlanning, toDayKey } from '../../lib/dates';
 import { addDays } from 'date-fns';
 import { CopyButton } from '../ui/CopyButton';
 import { cn } from '../../lib/utils';
@@ -10,7 +10,7 @@ import type { WeeklyPlan } from '../../types';
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 export function WeeklyPlanningView() {
-  const weekKey = getWeekKey(new Date());
+  const weekKey = getWeekKeyForPlanning(new Date());
   const existingPlan = usePlannerStore((s) => s.weeklyPlans[weekKey]);
 
   const [step, setStep] = useState(1);
@@ -82,7 +82,7 @@ export function WeeklyPlanningView() {
       }
     }
 
-    completeWeeklyPlanning();
+    completeWeeklyPlanning(weekKey);
   };
 
   return (

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -48,3 +48,15 @@ export function getWeekKey(date: Date = new Date()): string {
   const monday = startOfWeek(date, { weekStartsOn: 1 }); // 1 = Monday
   return format(monday, 'yyyy-MM-dd');
 }
+
+/** Returns the appropriate week key for weekly planning. 
+ * If it's Sunday, returns next week's key (since people want to plan ahead).
+ * Otherwise returns current week's key. */
+export function getWeekKeyForPlanning(date: Date = new Date()): string {
+  if (date.getDay() === 0) { // Sunday is 0
+    // On Sunday, plan for next week
+    const nextWeek = addDays(date, 1); // Move to Monday (next week)
+    return getWeekKey(nextWeek);
+  }
+  return getWeekKey(date);
+}

--- a/src/store/usePlannerStore.ts
+++ b/src/store/usePlannerStore.ts
@@ -123,7 +123,7 @@ interface PlannerState {
   snoozeWeeklyPlanning: () => void;
   snoozeWeeklyReview: () => void;
   saveWeeklyPlan: (plan: WeeklyPlan) => void;
-  completeWeeklyPlanning: () => void;
+  completeWeeklyPlanning: (weekKey?: string) => void;
   saveWeeklyReview: (review: WeeklyReview) => void;
   completeWeeklyReview: () => void;
   setWeeklyPlanningEnabled: (v: boolean) => void;
@@ -978,9 +978,10 @@ export const usePlannerStore = create<PlannerState>()(
           state.weeklyPlans[plan.weekKey] = plan;
         });
       },
-      completeWeeklyPlanning: () => {
+      completeWeeklyPlanning: (weekKey) => {
         set((state) => {
-          state.lastWeeklyPlanningDate = getWeekKey(new Date());
+          // Use provided weekKey or fall back to current week
+          state.lastWeeklyPlanningDate = weekKey || getWeekKey(new Date());
           state.showWeeklyPlanningPrompt = false;
           state.weeklyPlanningSnoozedUntil = null;
           state.view = 'weekPlan';


### PR DESCRIPTION
Fixes #32

## Summary
- When users access weekly planning on Sunday, they now plan for the upcoming week starting Monday instead of the current (almost-over) week
- Added `getWeekKeyForPlanning()` helper that detects Sunday and returns next week's key
- Updated completion tracking to properly record which week was actually planned

## Test plan
- [ ] Manually test weekly planning on different days of the week
- [ ] Verify that planning on Sunday creates plans for next week
- [ ] Verify that planning on other days still creates plans for current week
- [ ] Confirm completion tracking works correctly for both scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)