### PR TITLE
fix: properly render line breaks in notes and review text

### DIFF
--- a/src/components/ui/HashtagText.tsx
+++ b/src/components/ui/HashtagText.tsx
@@ -50,7 +50,14 @@ export function HashtagText({ text, onHashtagClick, className }: HashtagTextProp
         ) : /^\*\*[^*]+\*\*$/.test(part) ? (
           <strong key={i}>{part.slice(2, -2)}</strong>
         ) : (
-          <span key={i}>{part}</span>
+          <span key={i}>
+            {part.split('\n').map((line, lineIndex, lines) => (
+              <span key={lineIndex}>
+                {line}
+                {lineIndex < lines.length - 1 && <br />}
+              </span>
+            ))}
+          </span>
         )
       )}
     </span>


### PR DESCRIPTION
Fixes #34

## Summary
- Fixed missing line breaks in weekly/daily reviews displayed in the timeline
- The HashtagText component now properly handles newline characters by converting them to `<br>` elements
- This preserves the intended formatting for multi-line review text and ensures proper spacing between sections

## Test plan
- [ ] Complete a daily or weekly review with multi-line text in any of the sections
- [ ] Verify that the review note appears in the timeline with proper line breaks
- [ ] Check that section headers like "Priority reflections:" and "Wins:" appear on separate lines
- [ ] Confirm that double line breaks (paragraph spacing) are preserved

🤖 Generated with [Claude Code](https://claude.ai/code)