### PR TITLE
fix: display priorities and intentions in weekly review report

### DIFF
--- a/src/components/ritual/WeekReviewPage.tsx
+++ b/src/components/ritual/WeekReviewPage.tsx
@@ -5,6 +5,7 @@ import { addDays, format } from 'date-fns';
 
 export function WeekReviewPage() {
   const weeklyReviews = usePlannerStore((s) => s.weeklyReviews);
+  const weeklyPlans = usePlannerStore((s) => s.weeklyPlans);
   const setView = usePlannerStore((s) => s.setView);
 
   // Start with the most recent review or current week
@@ -12,6 +13,7 @@ export function WeekReviewPage() {
   const [selectedWeekKey, setSelectedWeekKey] = useState(allWeekKeys[0] ?? getWeekKey(new Date()));
 
   const review = weeklyReviews[selectedWeekKey];
+  const weeklyPlan = weeklyPlans[selectedWeekKey];
   const currentIdx = allWeekKeys.indexOf(selectedWeekKey);
 
   const mondayDate = new Date(selectedWeekKey + 'T00:00:00');
@@ -66,6 +68,29 @@ export function WeekReviewPage() {
           </p>
         ) : (
           <>
+            {/* Show weekly plan priorities and intentions if they exist */}
+            {weeklyPlan && weeklyPlan.priorities.length > 0 && (
+              <div className="mb-3 rounded-xl border border-blue-500/30 bg-blue-500/5 p-3">
+                <span className="text-xs font-semibold uppercase tracking-wider text-blue-400 mb-2 block">
+                  This week's priorities
+                </span>
+                {weeklyPlan.priorities.map((p) => (
+                  <div key={p.id} className="px-3 py-1.5">
+                    <span className="text-sm text-[var(--color-text-primary)]">{p.text}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {weeklyPlan && weeklyPlan.intentions?.trim() && (
+              <div className="mb-3 rounded-xl border border-amber-500/30 bg-amber-500/5 px-3 py-2">
+                <span className="text-xs font-semibold uppercase tracking-wider text-amber-400 block mb-1">
+                  This week's intention
+                </span>
+                <span className="text-sm text-[var(--color-text-primary)]">{weeklyPlan.intentions}</span>
+              </div>
+            )}
+
             {review.priorityReflections?.trim() && (
               <div className="mb-3 rounded-xl border border-blue-500/30 bg-blue-500/5 px-3 py-2">
                 <span className="text-xs font-semibold uppercase tracking-wider text-blue-400 block mb-1">

--- a/src/components/ritual/WeeklyReviewView.tsx
+++ b/src/components/ritual/WeeklyReviewView.tsx
@@ -29,6 +29,14 @@ export function WeeklyReviewView() {
 
     // Create a #weeklyreview note
     const lines: string[] = [];
+    if (weeklyPlan && weeklyPlan.priorities.length > 0) {
+      lines.push('**Priorities**');
+      weeklyPlan.priorities.forEach((p) => lines.push(`- ${p.text}`));
+      lines.push('');
+    }
+    if (weeklyPlan && weeklyPlan.intentions?.trim()) {
+      lines.push(`**Intention:** ${weeklyPlan.intentions.trim()}`, '');
+    }
     if (priorityReflections.trim()) lines.push(`**Priority reflections:** ${priorityReflections.trim()}`);
     if (wins.trim()) lines.push(`**Wins:** ${wins.trim()}`);
     if (learned.trim()) lines.push(`**Learned:** ${learned.trim()}`);


### PR DESCRIPTION
Fixes #36

## Summary
- Display the weekly plan's priorities and intentions in the weekly review report so users can see what they were originally reflecting upon
- Include priorities and intentions in the generated #weeklyreview note for consistency

## Problem
When users complete a weekly review, they can see their priorities and intentions during the reflection process, but these are not displayed in the final weekly review report. This makes it difficult to understand what was being reflected upon when reading the review later.

## Solution
- Modified `WeekReviewPage.tsx` to display the original priorities and intentions from the weekly plan above the reflection responses
- Updated `WeeklyReviewView.tsx` to include priorities and intentions in the generated #weeklyreview note
- Maintains the existing visual design patterns with consistent styling

## Test plan
- [x] Type checking passes
- [ ] Manual testing: Create a weekly plan with priorities and intentions, complete a weekly review, verify both the report page and generated note include the original priorities and intentions

---
🤖 Generated with [Claude Code](https://claude.ai/code)