### PR TITLE
fix: prevent duplicate recurring items when completing in hindsight

### DIFF
--- a/src/store/usePlannerStore.ts
+++ b/src/store/usePlannerStore.ts
@@ -338,8 +338,10 @@ export const usePlannerStore = create<PlannerState>()(
           // (only if one doesn't already exist — setRecurrence pre-generates future copies)
           if (patch.completed === true && item.recurrence && item.dayKey) {
             const nextDayKey = computeNextOccurrence(item.dayKey, item.recurrence);
+            // Check for any future instance of the same recurring item, not just the exact next occurrence.
+            // This prevents duplicates when completing items in hindsight from the timeline.
             const alreadyExists = Object.values(state.items).some(
-              (i) => i.dayKey === nextDayKey && i.text === item.text &&
+              (i) => i.dayKey && i.dayKey >= nextDayKey && i.text === item.text &&
                 !i.completed && i.recurrence &&
                 i.recurrence.type === item.recurrence!.type &&
                 i.recurrence.interval === item.recurrence!.interval


### PR DESCRIPTION
Fixes #41

## Summary
- Fixed duplicate recurring items appearing when checking off recurring tasks in hindsight from the timeline
- The issue occurred when users were offline for several days and then completed old recurring items - this would create duplicates on future days where the recurring items already existed

## What was wrong
When completing a recurring item, the code was only checking for an exact match at the computed "next occurrence" date. However, when completing items from past dates (in hindsight), the computed next occurrence might be in the past or present, and there could already be multiple future instances of the recurring item.

## How it was fixed
Changed the logic in `updateItem()` to check for **any future instance** of the same recurring item (`dayKey >= nextDayKey`) instead of just checking for an exact match at the computed next occurrence date. This prevents creating duplicates when future instances already exist.

## Testing
- TypeScript compilation passes
- Only affects web app (mobile doesn't have this auto-creation logic)

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_