### PR TITLE
fix: improve multi-line item display and editing

### DIFF
--- a/src/components/mobile/MobileTaskRow.tsx
+++ b/src/components/mobile/MobileTaskRow.tsx
@@ -12,7 +12,7 @@ export function MobileTaskRow({ item }: MobileTaskRowProps) {
   const promptDeleteItem = usePlannerStore((s) => s.promptDeleteItem);
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(item.text);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -42,20 +42,21 @@ export function MobileTaskRow({ item }: MobileTaskRowProps) {
         onClick={() => { if (!isEditing) { setEditText(item.text); setIsEditing(true); } }}
       >
         {isEditing ? (
-          <input
+          <textarea
             ref={inputRef}
             value={editText}
+            rows={Math.min(Math.max(editText.split('\n').length, 1), 10)}
             onChange={(e) => setEditText(e.target.value)}
             onBlur={commitEdit}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') { e.preventDefault(); commitEdit(); }
+              if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commitEdit(); }
               if (e.key === 'Escape') { setEditText(item.text); setIsEditing(false); }
             }}
-            className="w-full bg-transparent text-base text-[var(--color-text-primary)] outline-none"
+            className="w-full bg-transparent text-base text-[var(--color-text-primary)] outline-none resize-none"
           />
         ) : (
           <span
-            className={`text-base break-words ${
+            className={`text-base break-words whitespace-pre-wrap ${
               item.completed
                 ? 'line-through text-[var(--color-text-muted)]'
                 : 'text-[var(--color-text-primary)]'

--- a/src/components/ui/HashtagText.tsx
+++ b/src/components/ui/HashtagText.tsx
@@ -32,7 +32,7 @@ export function HashtagText({ text, onHashtagClick, className }: HashtagTextProp
   const parts = text.split(SPLIT_RE);
 
   return (
-    <span className={className}>
+    <span className={`${className} whitespace-pre-wrap`}>
       {parts.map((part, i) =>
         /^#[\w-]+$/.test(part) ? (
           <ColoredHashtag key={i} tag={part} onClick={() => onHashtagClick(part)} />


### PR DESCRIPTION
Fixes #43

## Summary
- Fixed multi-line items not displaying properly by adding `whitespace-pre-wrap` CSS class to preserve line breaks
- Fixed multi-line item editing on mobile by replacing single-line `<input>` with multi-line `<textarea>` 
- Added proper keyboard handling (Shift+Enter for new lines, Enter to save)
- Limited textarea height to max 10 rows to prevent UI overflow

## Test plan
- [ ] Create a multi-line task item on both web and mobile
- [ ] Verify line breaks are preserved in display mode
- [ ] Verify editing works correctly with proper line break handling
- [ ] Test keyboard shortcuts (Shift+Enter for new line, Enter to save, Escape to cancel)

🤖 Generated with [Claude Code](https://claude.ai/code)