### PR TITLE
fix: prevent task disappearing during sync race condition

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -217,7 +217,10 @@ export async function pullFromSupabase(): Promise<void> {
 
     // Apply merged items to store, then re-sort so completed/incomplete
     // grouping is consistent even when order values from different devices diverge.
+    // Set itemsPullDone BEFORE setState to ensure any new items created during
+    // the setState subscription get properly queued for sync.
     suppressDeleteSync = true;
+    itemsPullDone = true;
     usePlannerStore.setState({ items: merged });
     usePlannerStore.getState().resortAllDays();
     suppressDeleteSync = false;
@@ -237,7 +240,6 @@ export async function pullFromSupabase(): Promise<void> {
 
     // Persist updated knownRemoteIds after pull
     saveKnownRemoteIds();
-    itemsPullDone = true;
     // Flush any items/deletes that were queued before the first pull completed.
     // markChanged/markDeleted track IDs before itemsPullDone but don't schedule
     // the actual push — do that now.


### PR DESCRIPTION
Fixes #46

## Summary
- Fixed a race condition where tasks created immediately after page load could disappear
- The issue occurred when users created tasks before the initial Supabase sync completed
- Tasks would be tracked locally but not properly queued for sync to remote

## Root Cause
When users create tasks very early after page load:

1. User creates task before initial Supabase pull completes  
2. `markChanged()` tracks the change but doesn't schedule sync (`itemsPullDone=false`)
3. `pullFromSupabase()` calls `setState()` which triggers store subscription 
4. Subscription calls `markChanged()` again, but `itemsPullDone` is still false
5. New changes don't get queued for sync, causing tasks to disappear

## Solution
Set `itemsPullDone=true` BEFORE calling `setState()` during the initial pull. This ensures any items created during the setState subscription get properly queued for sync.

## Test Plan
- [x] TypeScript compilation passes
- [ ] Manual testing: Create tasks immediately after page load
- [ ] Verify tasks persist after refresh
- [ ] Test sync behavior with multiple devices

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_