### PR TITLE
fix: complete mobile support for past incomplete items when auto-advance disabled

### DIFF
--- a/src/components/mobile/MobileTodayView.tsx
+++ b/src/components/mobile/MobileTodayView.tsx
@@ -1,14 +1,37 @@
+import { useMemo } from 'react';
 import { usePlannerStore, selectItemsForDay } from '../../store/usePlannerStore';
 import { toDayKey, formatDayLabel } from '../../lib/dates';
 import { MobileTaskRow } from './MobileTaskRow';
 
 export function MobileTodayView() {
   const items = usePlannerStore((s) => s.items);
+  const autoAdvanceEnabled = usePlannerStore((s) => s.autoAdvanceEnabled);
+  const showPastIncompleteInToday = usePlannerStore((s) => s.showPastIncompleteInToday);
+  const setAutoAdvanceEnabled = usePlannerStore((s) => s.setAutoAdvanceEnabled);
+  const setShowPastIncompleteInToday = usePlannerStore((s) => s.setShowPastIncompleteInToday);
 
   const today = new Date();
   const dayKey = toDayKey(today);
   const todayItems = selectItemsForDay(items, dayKey);
   const label = formatDayLabel(today);
+
+  // When auto-advance is disabled and the section isn't hidden, surface past
+  // incomplete tasks in a distinct section below today's items.
+  const pastIncompleteItems = useMemo(() => {
+    if (autoAdvanceEnabled || !showPastIncompleteInToday) return [];
+    return Object.values(items)
+      .filter(
+        (i) =>
+          i.dayKey !== null &&
+          i.dayKey < dayKey &&
+          !i.completed &&
+          !i.isLater &&
+          !i.parentId &&
+          !i.isArchived &&
+          i.type !== 'note',
+      )
+      .sort((a, b) => (b.dayKey || '').localeCompare(a.dayKey || ''));
+  }, [items, autoAdvanceEnabled, showPastIncompleteInToday, dayKey]);
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -24,6 +47,34 @@ export function MobileTodayView() {
           <MobileTaskRow key={item.id} item={item} />
         ))}
       </div>
+
+      {/* Past incomplete items */}
+      {pastIncompleteItems.length > 0 && (
+        <div className="mt-6 px-5">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-3">
+            Past unfinished ({pastIncompleteItems.length})
+          </h3>
+          <div className="space-y-0.5">
+            {pastIncompleteItems.map((item) => (
+              <MobileTaskRow key={item.id} item={item} />
+            ))}
+          </div>
+          <div className="mt-4 flex gap-3 text-xs">
+            <button
+              onClick={() => setShowPastIncompleteInToday(false)}
+              className="px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text-primary)] transition-colors"
+            >
+              Hide from Today
+            </button>
+            <button
+              onClick={() => setAutoAdvanceEnabled(true)}
+              className="px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text-primary)] transition-colors"
+            >
+              Turn on auto-advance
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Spacer for FAB */}
       <div className="h-24" />


### PR DESCRIPTION
Fixes #48

## Summary
- Extended the fix from PR #22 to the mobile app
- Mobile TodayView now shows past incomplete items when auto-advance is disabled
- Prevents tasks from disappearing on mobile devices when auto-advance is turned off

## What was wrong
PR #22 fixed task disappearing issues on the web app when auto-advance was disabled, but the mobile app (`MobileTodayView.tsx`) was not updated with the same logic. This meant mobile users continued to experience tasks disappearing when:
1. Auto-advance was disabled
2. Tasks were created on previous days 
3. Day changed - tasks became invisible since mobile view only showed current day items

## How it was fixed
- Added `pastIncompleteItems` logic to `MobileTodayView.tsx` matching the web implementation
- Added past incomplete items section with count display
- Added "Hide from Today" and "Turn on auto-advance" buttons for user control
- Maintains consistent UX between web and mobile platforms

## Test plan
- [ ] Disable auto-advance in settings on mobile
- [ ] Create some tasks in Today view on mobile
- [ ] Wait for day to change (or manually change system date)  
- [ ] Verify tasks are still visible in "Past unfinished" section on mobile
- [ ] Test hide/show controls work correctly on mobile
- [ ] Verify auto-advance toggle works from mobile view

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_