### PR TITLE
fix: ensure task deduplication runs even when auto-advance disabled

### DIFF
--- a/src/store/usePlannerStore.ts
+++ b/src/store/usePlannerStore.ts
@@ -669,7 +669,6 @@ export const usePlannerStore = create<PlannerState>()(
       },
 
       autoMoveIncompleteItems: () => {
-        if (!get().autoAdvanceEnabled) return;
         const todayKey = toDayKey(new Date());
         // Track whether this is the first run of the day — only increment
         // consecutiveMoves on the first run to avoid inflating the counter
@@ -701,6 +700,9 @@ export const usePlannerStore = create<PlannerState>()(
               delete item.isMediumPriority;
             }
           });
+
+          // If auto-advance is disabled, stop here (only do cleanup, no moving)
+          if (!state.autoAdvanceEnabled) return;
 
           const pastIncomplete = Object.values(state.items).filter(
             (i) =>


### PR DESCRIPTION
Fixes #50

## Summary
- Fixed a bug where tasks would appear to "disappear" when auto-advance was disabled
- The issue was caused by the `autoMoveIncompleteItems` function returning early when auto-advance was disabled, preventing crucial cleanup operations from running
- Separated cleanup logic (task deduplication and stale priority clearing) from auto-advance logic

## Root Cause
The `autoMoveIncompleteItems` function in `/src/store/usePlannerStore.ts` had an early return when `autoAdvanceEnabled` was false. This prevented essential cleanup operations from running:

1. **Task deduplication** - Removes duplicate recurring tasks that can cause display conflicts
2. **Stale priority clearing** - Removes old priority flags from past days

When these cleanup operations didn't run, users would see tasks "disappear" because duplicate recurring tasks would conflict with each other in the UI.

## Solution
Moved the auto-advance check from the very beginning of the function to after the cleanup operations. Now:

- ✅ Cleanup operations (deduplication, priority clearing) **always run**
- ✅ Task movement only happens when auto-advance is **enabled**
- ✅ No behavioral changes when auto-advance is enabled
- ✅ Tasks no longer disappear when auto-advance is disabled

## Test Plan
- [x] Verified the fix with TypeScript compilation (`npx tsc --noEmit`)
- [ ] **Manual testing needed**: Test task creation with auto-advance disabled to verify tasks no longer disappear
- [ ] **Regression testing**: Test that auto-advance still works properly when enabled

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_