### PR TITLE
fix: allow Sunday weekly planning to plan for the upcoming week

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { AppShell } from './components/layout/AppShell';
 import { MobileApp } from './components/mobile/MobileApp';
 import { useIsMobile } from './hooks/useIsMobile';
 import { usePlannerStore } from './store/usePlannerStore';
-import { toDayKey, getWeekKey } from './lib/dates';
+import { toDayKey, getWeekKey, getWeeklyPlanningWeekKey } from './lib/dates';
 import { supabase } from './lib/supabase';
 import { useAuthStore } from './store/useAuthStore';
 import { pullFromSupabase, pullPreferences, flushPreferencesNow, flushChangedNow, flushDeletedNow, subscribeToRealtime } from './lib/sync';
@@ -80,8 +80,8 @@ export default function App() {
     const state = usePlannerStore.getState();
     if (!state.weeklyPlanningEnabled) return;
     const now = new Date();
-    const currentWeekKey = getWeekKey(now);
-    if (state.lastWeeklyPlanningDate === currentWeekKey) return;
+    const targetWeekKey = getWeeklyPlanningWeekKey(now, state.weeklyPlanningDay);
+    if (state.lastWeeklyPlanningDate === targetWeekKey) return;
     if (now.getDay() !== state.weeklyPlanningDay) return;
     if (now.getHours() < state.weeklyPlanningHour) return;
     if (state.weeklyPlanningSnoozedUntil && Date.now() < state.weeklyPlanningSnoozedUntil) return;
@@ -199,13 +199,14 @@ export default function App() {
           const s = usePlannerStore.getState();
           const todayKey = toDayKey(new Date());
           const weekKey = getWeekKey(new Date());
+          const weeklyPlanningWeekKey = getWeeklyPlanningWeekKey(new Date(), s.weeklyPlanningDay);
           if (s.lastRitualDate === todayKey && s.showRitualPrompt) {
             s.setShowRitualPrompt(false);
           }
           if (s.lastReviewRitualDate === todayKey && s.showReviewRitualPrompt) {
             s.setShowReviewRitualPrompt(false);
           }
-          if (s.lastWeeklyPlanningDate === weekKey && s.showWeeklyPlanningPrompt) {
+          if (s.lastWeeklyPlanningDate === weeklyPlanningWeekKey && s.showWeeklyPlanningPrompt) {
             s.setShowWeeklyPlanningPrompt(false);
           }
           if (s.lastWeeklyReviewDate === weekKey && s.showWeeklyReviewPrompt) {

--- a/src/components/ritual/WeeklyPlanningView.tsx
+++ b/src/components/ritual/WeeklyPlanningView.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { nanoid } from 'nanoid';
 import { usePlannerStore } from '../../store/usePlannerStore';
-import { getWeekKey, toDayKey } from '../../lib/dates';
+import { getWeeklyPlanningWeekKey, toDayKey } from '../../lib/dates';
 import { addDays } from 'date-fns';
 import { CopyButton } from '../ui/CopyButton';
 import { cn } from '../../lib/utils';
@@ -10,7 +10,8 @@ import type { WeeklyPlan } from '../../types';
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 export function WeeklyPlanningView() {
-  const weekKey = getWeekKey(new Date());
+  const weeklyPlanningDay = usePlannerStore((s) => s.weeklyPlanningDay);
+  const weekKey = getWeeklyPlanningWeekKey(new Date(), weeklyPlanningDay);
   const existingPlan = usePlannerStore((s) => s.weeklyPlans[weekKey]);
 
   const [step, setStep] = useState(1);

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -48,3 +48,18 @@ export function getWeekKey(date: Date = new Date()): string {
   const monday = startOfWeek(date, { weekStartsOn: 1 }); // 1 = Monday
   return format(monday, 'yyyy-MM-dd');
 }
+
+/** 
+ * Returns the week key for weekly planning purposes.
+ * If it's Sunday and the planning day is Sunday (0), plan for next week.
+ * Otherwise, plan for the current week.
+ */
+export function getWeeklyPlanningWeekKey(date: Date = new Date(), planningDay: number): string {
+  if (date.getDay() === 0 && planningDay === 0) {
+    // It's Sunday and Sunday is the planning day - plan for next week
+    const nextWeek = addDays(date, 7);
+    return getWeekKey(nextWeek);
+  }
+  // For all other cases, plan for the current week
+  return getWeekKey(date);
+}

--- a/src/store/usePlannerStore.ts
+++ b/src/store/usePlannerStore.ts
@@ -4,7 +4,7 @@ import { immer } from 'zustand/middleware/immer';
 import { nanoid } from 'nanoid';
 import type { PlannerItem, ItemType, Recurrence, CustomList, WeeklyPlan, WeeklyReview } from '../types';
 import { computeNextOccurrence } from '../lib/recurrence';
-import { toDayKey, getWeekKey } from '../lib/dates';
+import { toDayKey, getWeekKey, getWeeklyPlanningWeekKey } from '../lib/dates';
 
 export const LABEL_PALETTE = [
   '#D20000', '#F65353', '#EA7D70', '#FD5E00', '#F58553',
@@ -980,7 +980,7 @@ export const usePlannerStore = create<PlannerState>()(
       },
       completeWeeklyPlanning: () => {
         set((state) => {
-          state.lastWeeklyPlanningDate = getWeekKey(new Date());
+          state.lastWeeklyPlanningDate = getWeeklyPlanningWeekKey(new Date(), state.weeklyPlanningDay);
           state.showWeeklyPlanningPrompt = false;
           state.weeklyPlanningSnoozedUntil = null;
           state.view = 'weekPlan';


### PR DESCRIPTION
Fixes #53

## Summary
- Fixed weekly planning to plan for the next week when triggered on Sunday instead of the current week
- Added `getWeeklyPlanningWeekKey()` helper function to handle the Sunday planning logic consistently
- Updated all related components to use the new helper for consistent behavior

## Problem
When users set Sunday as their weekly planning day (Sunday = day 0), they want to plan for the upcoming week, but the app was planning for the current week that's about to finish. This made Sunday planning essentially useless since users would be planning for a week that was already over.

## Solution
The new `getWeeklyPlanningWeekKey()` function detects when:
1. Today is Sunday (day 0)
2. Sunday is configured as the weekly planning day

In this case, it returns the Monday of the next week instead of the current week. For all other scenarios, it continues to use the current week logic.

## Changes
- **Added**: `getWeeklyPlanningWeekKey()` in `src/lib/dates.ts`
- **Updated**: `WeeklyPlanningView` to use the correct week key for planning
- **Updated**: Store's `completeWeeklyPlanning()` to track the correct week completion
- **Updated**: App.tsx ritual checking logic to use consistent week determination

## Testing
- Type checking passes ✅
- Logic verified: Sunday planning now targets next week when Sunday is the planning day
- Backward compatible: No changes for non-Sunday planning days

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_