### PR TITLE
fix: add 'Today' as clickable option in move dialog

### DIFF
--- a/src/components/ui/MoveModal.tsx
+++ b/src/components/ui/MoveModal.tsx
@@ -22,6 +22,7 @@ function buildPresets(): Preset[] {
   const monday = nextMonday(today);
 
   return [
+    { label: 'Today', date: today, dayKey: toDayKey(today) },
     { label: 'Tomorrow', date: tomorrow, dayKey: toDayKey(tomorrow) },
     { label: 'Later this week', date: laterThisWeek, dayKey: toDayKey(laterThisWeek) },
     { label: 'This weekend', date: weekend, dayKey: toDayKey(weekend) },


### PR DESCRIPTION
Fixes #55

## What was the issue?
When using the move dialog (ctrl+M), users could type "Today" and it would work, but there was no clickable "Today" button in the preset options. Only "Tomorrow", "Later this week", "This weekend", and "Next week" were available as clickable presets.

## What was fixed?
Added "Today" as the first preset option in the move dialog's `buildPresets()` function. Now users can click "Today" instead of having to type it.

## Changes made
- Modified `src/components/ui/MoveModal.tsx` line 25 to include `{ label: 'Today', date: today, dayKey: toDayKey(today) }` as the first preset option

The fix is minimal and follows the existing pattern used for other preset options.

---
_Auto-generated fix from bug report. **Awaits human review before merge.**_